### PR TITLE
feat: Add fulfillment tracking

### DIFF
--- a/pbd_projekt.sql
+++ b/pbd_projekt.sql
@@ -140,6 +140,15 @@ CREATE TABLE [Orders] (
 );
 GO
 
+ALTER TABLE [Orders]
+ADD CONSTRAINT [CK_Orders_fulfillmentDates] 
+CHECK ([FulfillmentFinish] >= [FulfillmentStart]);
+
+
+ALTER TABLE [Orders]
+ADD CONSTRAINT [CK_Orders_FulfillmentStart_vs_OrderDate] 
+CHECK ([FulfillmentStart] >= [OrderDate]);
+
 EXEC sys.sp_addextendedproperty
     @name=N'MS_Description', @value=N'Lista zamówień',
     @level0type=N'SCHEMA',@level0name=N'dbo',


### PR DESCRIPTION
Nie mamy teraz żadnego sposobu, żeby śledzić postępy w realizacji zamówienia oraz odróżnić zamówienia zrealizowane od niezrealizowanych.

Dodałem kolumnę `QuantityFulfilled` w tabeli `OrderDetails`, która powinna śledzić ilość produktów, które zostały przeznaczone na dane zamówienie (wyciągnięte z magazynu albo wyprodukowane przez pracownika). Jeśli `QuantityFulfilled` = `Quantity` w każdym wierszu w tabeli `OrderDetails`, dla którego `OrderDetails.OrderID` = `Orders.OrderID` to zamówienie można uznać za zrealizowane całkowicie.